### PR TITLE
Make isDisplayed use attempt to catch Stale Element Exceptions

### DIFF
--- a/src/main/java/com/redhat/darcy/webdriver/elements/WebDriverElement.java
+++ b/src/main/java/com/redhat/darcy/webdriver/elements/WebDriverElement.java
@@ -66,8 +66,8 @@ public class WebDriverElement implements Element, Caching, HtmlElement, WrapsEle
     @Override
     public boolean isDisplayed() {
         try {
-            return getWrappedElement().isDisplayed();
-        } catch (NotFoundException e) {
+            return attemptAndGet(WebElement::isDisplayed);
+        } catch (FindableNotPresentException e) {
             return false;
         }
     }


### PR DESCRIPTION
Updated per issue 42.  I also had to change the  catch because webElement() already catches NotFoundException and throws FinableNotPresentException instead.  See https://github.com/darcy-framework/darcy-webdriver/blob/master/src/main/java/com/redhat/darcy/webdriver/elements/WebDriverElement.java#L204