### PR TITLE
Implement FindsByTitle in WebDriverParentContext

### DIFF
--- a/src/main/java/com/redhat/darcy/webdriver/WebDriverBrowser.java
+++ b/src/main/java/com/redhat/darcy/webdriver/WebDriverBrowser.java
@@ -318,6 +318,16 @@ public class WebDriverBrowser implements Browser, Frame, WebDriverWebContext, Wr
     }
 
     @Override
+    public <T> List<T> findAllByTitle(Class<T> type, String title) {
+        return attemptAndGet(() -> webContext.findAllByTitle(type, title));
+    }
+
+    @Override
+    public <T> T findByTitle(Class<T> type, String title) {
+        return attemptAndGet(() -> webContext.findByTitle(type, title));
+    }
+
+    @Override
     public TargetedWebDriver getWrappedDriver() {
         return driver;
     }

--- a/src/main/java/com/redhat/darcy/webdriver/WebDriverParentContext.java
+++ b/src/main/java/com/redhat/darcy/webdriver/WebDriverParentContext.java
@@ -22,9 +22,11 @@ package com.redhat.darcy.webdriver;
 import com.redhat.darcy.ui.api.ParentContext;
 import com.redhat.darcy.ui.internal.FindsById;
 import com.redhat.darcy.ui.internal.FindsByName;
+import com.redhat.darcy.ui.internal.FindsByTitle;
 import com.redhat.darcy.ui.internal.FindsByView;
 import com.redhat.darcy.web.api.Alert;
 
-public interface WebDriverParentContext extends ParentContext, FindsById, FindsByName, FindsByView {
+public interface WebDriverParentContext extends ParentContext, FindsById, FindsByName, FindsByView,
+        FindsByTitle {
     Alert alert();
 }

--- a/src/main/java/com/redhat/darcy/webdriver/internal/DelegatingWebContext.java
+++ b/src/main/java/com/redhat/darcy/webdriver/internal/DelegatingWebContext.java
@@ -31,6 +31,7 @@ import com.redhat.darcy.ui.internal.FindsByName;
 import com.redhat.darcy.ui.internal.FindsByNested;
 import com.redhat.darcy.ui.internal.FindsByPartialTextContent;
 import com.redhat.darcy.ui.internal.FindsByTextContent;
+import com.redhat.darcy.ui.internal.FindsByTitle;
 import com.redhat.darcy.ui.internal.FindsByView;
 import com.redhat.darcy.ui.internal.FindsByXPath;
 import com.redhat.darcy.web.api.Alert;
@@ -356,6 +357,28 @@ public class DelegatingWebContext implements WebDriverWebContext {
             return context.findByView(type, view);
         } catch (ClassCastException e) {
             throw unsupportedLocatorForType("view, " + view, type);
+        }
+    }
+
+    @Override
+    public <T> List<T> findAllByTitle(Class<T> type, String title) {
+        try {
+            FindsByTitle context = (FindsByTitle) contextForType(type);
+
+            return context.findAllByTitle(type, title);
+        } catch (ClassCastException e) {
+            throw unsupportedLocatorForType("title, " + title, type);
+        }
+    }
+
+    @Override
+    public <T> T findByTitle(Class<T> type, String title) {
+        try {
+            FindsByTitle context = (FindsByTitle) contextForType(type);
+
+            return context.findByTitle(type, title);
+        } catch (ClassCastException e) {
+            throw unsupportedLocatorForType("title, " + title, type);
         }
     }
 

--- a/src/test/java/com/redhat/darcy/webdriver/internal/WindowTitleWebDriverTargetTest.java
+++ b/src/test/java/com/redhat/darcy/webdriver/internal/WindowTitleWebDriverTargetTest.java
@@ -1,0 +1,86 @@
+/*
+ Copyright 2014 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of darcy-webdriver.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.darcy.webdriver.internal;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.openqa.selenium.NoSuchWindowException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriver.TargetLocator;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+@RunWith(JUnit4.class)
+public class WindowTitleWebDriverTargetTest {
+
+    private final WebDriver driver = mock(WebDriver.class);
+    private final WebDriver fooWindow = mock(WebDriver.class);
+    private final WebDriver barWindow = mock(WebDriver.class);
+    private final TargetLocator locator = mock(TargetLocator.class);
+
+    @Before
+    public void stubMocks() {
+        when(driver.getWindowHandles()).thenReturn(new HashSet<>(asList("fooWindow", "barWindow")));
+
+        when(fooWindow.getTitle()).thenReturn("foo");
+        when(barWindow.getTitle()).thenReturn("bar");
+
+        when(locator.defaultContent()).thenReturn(driver);
+        when(locator.window("fooWindow")).thenReturn(fooWindow);
+        when(locator.window("barWindow")).thenReturn(barWindow);
+    }
+
+    @Test
+    public void shouldTargetAWindowWhichExactlyMatchesTitle() {
+        WebDriverTarget target = WebDriverTargets.windowByTitle("foo");
+        WebDriver found = target.switchTo(locator);
+
+        assertThat(found.getTitle(), is("foo"));
+    }
+
+    @Test
+    public void shouldKeepFindingTheSameWindowEvenIfItsTitleLaterChanges() {
+        WebDriverTarget target = WebDriverTargets.windowByTitle("foo");
+
+        WebDriver found = target.switchTo(locator);
+        assertThat(found.getTitle(), is("foo"));
+
+        when(fooWindow.getTitle()).thenReturn("no longer foo");
+
+        WebDriver foundAgain = target.switchTo(locator);
+        assertThat(foundAgain.getTitle(), is("no longer foo"));
+    }
+
+    @Test(expected = NoSuchWindowException.class)
+    public void shouldThrowNoSuchWindowExceptionIfNoWindowsCanBeFoundWithTitle() {
+        WebDriverTarget target = WebDriverTargets.windowByTitle("awesome window");
+
+        target.switchTo(locator);
+    }
+}

--- a/src/test/java/com/redhat/darcy/webdriver/internal/WindowTitleWebDriverTargetTest.java
+++ b/src/test/java/com/redhat/darcy/webdriver/internal/WindowTitleWebDriverTargetTest.java
@@ -33,7 +33,6 @@ import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriver.TargetLocator;
 
-import java.util.Arrays;
 import java.util.HashSet;
 
 @RunWith(JUnit4.class)

--- a/src/test/java/com/redhat/darcy/webdriver/testing/doubles/StubWebDriverParentContext.java
+++ b/src/test/java/com/redhat/darcy/webdriver/testing/doubles/StubWebDriverParentContext.java
@@ -53,11 +53,21 @@ public class StubWebDriverParentContext implements WebDriverParentContext {
 
     @Override
     public <T> List<T> findAllByView(Class<T> type, View view) {
-        throw new UnsupportedOperationException("findllByView");
+        throw new UnsupportedOperationException("findAllByView");
     }
 
     @Override
     public <T> T findByView(Class<T> type, View view) {
         throw new UnsupportedOperationException("findByView");
+    }
+
+    @Override
+    public <T> List<T> findAllByTitle(Class<T> type, String title) {
+        throw new UnsupportedOperationException("findAllByTitle");
+    }
+
+    @Override
+    public <T> T findByTitle(Class<T> type, String title) {
+        throw new UnsupportedOperationException("findByTitle");
     }
 }


### PR DESCRIPTION
/cc @jvervaec I think you might be able to use this to solve your issue with Salesforce automation.

I forgot that WebDriver's finding window by "name" is not the "name" (title) of the window. It is the value of the "target" attribute on the link that opened the window. Not sure how that is set if the window is created via javascript (as it is was in your case). In any case, you may be able to do `transition().to(foo).inNewContext(By.title("Salesforce...blahblah..."))` with this, provided there aren't any issues with the window closing itself still.