### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/src/main/java/com/redhat/darcy/webdriver/guice/Browsers.java
+++ b/src/main/java/com/redhat/darcy/webdriver/guice/Browsers.java
@@ -37,14 +37,6 @@ public enum Browsers implements BrowserType {
     OPERA(DesiredCapabilities.opera(), new OperaBrowserFactory()),
     SAFARI(DesiredCapabilities.safari(), new SafariBrowserFactory());
 
-    /**
-     * Picks a browser type based off of the "darcy.browser" environment variable. Case-insensitive.
-     * Defaults to Firefox.
-     */
-    public static Browsers getBrowserFromEnv() {
-        return valueOf(System.getProperty("darcy.browser", "firefox").toUpperCase());
-    }
-
     private final DesiredCapabilities caps;
     private final BrowserFactory factory;
 
@@ -61,5 +53,13 @@ public enum Browsers implements BrowserType {
     @Override
     public BrowserFactory asBrowserFactory() {
         return factory;
+    }
+    
+    /**
+     * Picks a browser type based off of the "darcy.browser" environment variable. Case-insensitive.
+     * Defaults to Firefox.
+     */
+    public static Browsers getBrowserFromEnv() {
+        return valueOf(System.getProperty("darcy.browser", "firefox").toUpperCase());
     }
 }

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByAttribute.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByAttribute.java
@@ -36,6 +36,11 @@ public class ByAttribute extends By {
     protected final String attribute;
     protected final String word;
     
+    public ByAttribute(String attribute, String word) {
+        this.attribute = attribute;
+        this.word = word;
+    }
+    
     /**
      * Returns instance of ByAttribute that will search under the "value" 
      * attribute.
@@ -52,11 +57,6 @@ public class ByAttribute extends By {
     
     public static By labelFor(String what) {
         return new ByAttribute("for", what);
-    }
-    
-    public ByAttribute(String attribute, String word) {
-        this.attribute = attribute;
-        this.word = word;
     }
     
     @Override

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialVisibleText.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialVisibleText.java
@@ -35,12 +35,12 @@ import java.util.List;
 public class ByPartialVisibleText extends By {
     private final String text;
     
-    public static By ignoringCase(String text) {
-        return new ByPartialVisibleTextIgnoreCase(text);
-    }
-    
     public ByPartialVisibleText(String text) {
         this.text = text;
+    }
+    
+    public static By ignoringCase(String text) {
+        return new ByPartialVisibleTextIgnoreCase(text);
     }
 
     @Override

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleText.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleText.java
@@ -37,15 +37,15 @@ public class ByVisibleText extends By {
     protected final String text;
     private final ByPartialVisibleText byPartialVisibleText;
     
-    public static By ignoringCase(String text) {
-        return new ByVisibleTextIgnoreCase(text);
-    }
-    
     public ByVisibleText(String text) {
         this.text = text.trim();
         this.byPartialVisibleText = new ByPartialVisibleText(text);
     }
-
+    
+    public static By ignoringCase(String text) {
+        return new ByVisibleTextIgnoreCase(text);
+    }
+    
     @Override
     public List<WebElement> findElements(SearchContext context) {
         List<WebElement> result = new ArrayList<WebElement>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed