### PR TITLE
Code quality fix - "equals(Object obj)" and "hashCode()" should be overridden in pairs.

### DIFF
--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByAttribute.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByAttribute.java
@@ -75,7 +75,29 @@ public class ByAttribute extends By {
     public int hashCode() {
         return toString().hashCode();
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ByAttribute other = (ByAttribute) obj;
+        if (attribute == null) {
+            if (other.attribute != null)
+                return false;
+        } else if (!attribute.equals(other.attribute))
+            return false;
+        if (word == null) {
+            if (other.word != null)
+                return false;
+        } else if (!word.equals(other.word))
+            return false;
+        return true;
+    }
+
     @Override
     public String toString() {
       return "ByAttribute(\"" + attribute + "\"): " + word;

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialAttribute.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialAttribute.java
@@ -52,12 +52,34 @@ public class ByPartialAttribute extends By {
       return ((FindsByXPath) context).findElementByXPath(".//*["
           + attributeContains(attribute, word) + "]");
     }
-    
+
     @Override
     public int hashCode() {
         return toString().hashCode();
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ByPartialAttribute other = (ByPartialAttribute) obj;
+        if (attribute == null) {
+            if (other.attribute != null)
+                return false;
+        } else if (!attribute.equals(other.attribute))
+            return false;
+        if (word == null) {
+            if (other.word != null)
+                return false;
+        } else if (!word.equals(other.word))
+            return false;
+        return true;
+    }
+
     @Override
     public String toString() {
       return "ByPartialAttribute(\"" + attribute + "\"): " + word;

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialVisibleText.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialVisibleText.java
@@ -54,12 +54,29 @@ public class ByPartialVisibleText extends By {
         return ((FindsByXPath) context).findElementByXPath(".//*["
                 + textContains(text) + "]");
     }
-    
+
     @Override
     public int hashCode() {
         return toString().hashCode();
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ByPartialVisibleText other = (ByPartialVisibleText) obj;
+        if (text == null) {
+            if (other.text != null)
+                return false;
+        } else if (!text.equals(other.text))
+            return false;
+        return true;
+    }
+
     @Override
     public String toString() {
         return "ByPartialVisibleText: " + text;

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialVisibleTextIgnoreCase.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByPartialVisibleTextIgnoreCase.java
@@ -50,12 +50,29 @@ public class ByPartialVisibleTextIgnoreCase extends By {
         return ((FindsByXPath) context).findElementByXPath(".//*["
                 + textContainsIgnoringCase(text) + "]");
     }
-    
+
     @Override
     public int hashCode() {
         return toString().hashCode();
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ByPartialVisibleTextIgnoreCase other = (ByPartialVisibleTextIgnoreCase) obj;
+        if (text == null) {
+            if (other.text != null)
+                return false;
+        } else if (!text.equals(other.text))
+            return false;
+        return true;
+    }
+
     @Override
     public String toString() {
         return "ByPartialVisibleTextIgnoreCase: " + text;

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleText.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleText.java
@@ -65,12 +65,34 @@ public class ByVisibleText extends By {
         
         return result;
     }
-    
+
     @Override
     public int hashCode() {
         return toString().hashCode();
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ByVisibleText other = (ByVisibleText) obj;
+        if (byPartialVisibleText == null) {
+            if (other.byPartialVisibleText != null)
+                return false;
+        } else if (!byPartialVisibleText.equals(other.byPartialVisibleText))
+            return false;
+        if (text == null) {
+            if (other.text != null)
+                return false;
+        } else if (!text.equals(other.text))
+            return false;
+        return true;
+    }
+
     @Override
     public String toString() {
         return "ByVisibleText: " + text;

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleTextIgnoreCase.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleTextIgnoreCase.java
@@ -67,12 +67,35 @@ public class ByVisibleTextIgnoreCase extends By {
         
         return result;
     }
-    
+
     @Override
     public int hashCode() {
         return toString().hashCode();
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ByVisibleTextIgnoreCase other = (ByVisibleTextIgnoreCase) obj;
+        if (byPartialVisibleTextIgnoreCase == null) {
+            if (other.byPartialVisibleTextIgnoreCase != null)
+                return false;
+        } else if (!byPartialVisibleTextIgnoreCase
+                .equals(other.byPartialVisibleTextIgnoreCase))
+            return false;
+        if (text == null) {
+            if (other.text != null)
+                return false;
+        } else if (!text.equals(other.text))
+            return false;
+        return true;
+    }
+
     @Override
     public String toString() {
         return "ByVisibleTextIgnoreCase: " + text;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1206- "equals(Object obj)" and "hashCode()" should be overridden in pairs
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1206

Please let me know if you have any questions.

Faisal Hameed