### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/com/redhat/darcy/webdriver/internal/TargetedWebDriverParentContext.java
+++ b/src/main/java/com/redhat/darcy/webdriver/internal/TargetedWebDriverParentContext.java
@@ -131,7 +131,7 @@ public class TargetedWebDriverParentContext implements WebDriverParentContext {
                     + "available frames.");
         }
 
-        return (List<T>) new LazyList<Browser>(new FoundByViewSupplier(view));
+        return (List<T>) new LazyList<>(new FoundByViewSupplier(view));
     }
 
     @SuppressWarnings("unchecked")
@@ -161,7 +161,7 @@ public class TargetedWebDriverParentContext implements WebDriverParentContext {
                     + "available frames.");
         }
 
-        return (List<T>) new LazyList<Browser>(new FoundByTitleSupplier(title));
+        return (List<T>) new LazyList<>(new FoundByTitleSupplier(title));
     }
 
     @SuppressWarnings("unchecked")
@@ -190,7 +190,7 @@ public class TargetedWebDriverParentContext implements WebDriverParentContext {
                     + "available frames.");
         }
 
-        return (List<T>) new LazyList<Browser>(new FoundByUrlSupplier(urlMatcher));
+        return (List<T>) new LazyList<>(new FoundByUrlSupplier(urlMatcher));
     }
 
     @Override

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByChained.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByChained.java
@@ -71,7 +71,7 @@ public class ByChained extends By {
             }
         }
 
-        return found.stream()
+        return found == null ? null : found.stream()
                 .map(WebDriverElement::getWrappedElement)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleText.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleText.java
@@ -48,7 +48,7 @@ public class ByVisibleText extends By {
 
     @Override
     public List<WebElement> findElements(SearchContext context) {
-        List<WebElement> result = new ArrayList<WebElement>();
+        List<WebElement> result = new ArrayList<>();
         
         // First find any elements that *contain* this text.
         List<WebElement> elems = byPartialVisibleText.findElements(context);

--- a/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleTextIgnoreCase.java
+++ b/src/main/java/com/redhat/darcy/webdriver/locators/ByVisibleTextIgnoreCase.java
@@ -45,7 +45,7 @@ public class ByVisibleTextIgnoreCase extends By {
 
     @Override
     public List<WebElement> findElements(SearchContext context) {
-        List<WebElement> result = new ArrayList<WebElement>();
+        List<WebElement> result = new ArrayList<>();
         
         // First find any elements that *contain* this text.
         List<WebElement> elems = byPartialVisibleTextIgnoreCase.findElements(context);
@@ -60,7 +60,7 @@ public class ByVisibleTextIgnoreCase extends By {
             }
         }
         
-        if (result.size() == 0) {
+        if (result.isEmpty()) {
             throw new NoSuchElementException("Cannot locate an element using "
                     + toString());
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S2293 - The diamond operator ("<>") should be used.
squid:S2259- Null pointers should not be dereferenced.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.

Faisal Hameed