### PR TITLE
Use selenium 2.53.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ maven
 <dependency>
     <groupId>com.redhat.darcy</groupId>
     <artifactId>darcy-webdriver</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <version.synq>0.1.2-SNAPSHOT</version.synq>
         <version.darcy-web>0.3.0-SNAPSHOT</version.darcy-web>
-        <version.selenium>2.52.0</version.selenium>
+        <version.selenium>2.53.1</version.selenium>
         <version.operadriver>1.5</version.operadriver>
         <version.guice>4.0-beta5</version.guice>
         <version.guiceberry>3.3.1</version.guiceberry>

--- a/src/main/java/com/redhat/darcy/webdriver/internal/ForwardingTargetedWebDriver.java
+++ b/src/main/java/com/redhat/darcy/webdriver/internal/ForwardingTargetedWebDriver.java
@@ -21,6 +21,7 @@ package com.redhat.darcy.webdriver.internal;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;

--- a/src/main/java/com/redhat/darcy/webdriver/internal/ForwardingTargetedWebDriver.java
+++ b/src/main/java/com/redhat/darcy/webdriver/internal/ForwardingTargetedWebDriver.java
@@ -21,7 +21,6 @@ package com.redhat.darcy.webdriver.internal;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -36,7 +35,6 @@ import org.openqa.selenium.internal.FindsByName;
 import org.openqa.selenium.internal.FindsByTagName;
 import org.openqa.selenium.internal.FindsByXPath;
 import org.openqa.selenium.internal.WrapsDriver;
-import org.openqa.selenium.remote.SessionNotFoundException;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/redhat/darcy/webdriver/internal/ForwardingTargetedWebDriver.java
+++ b/src/main/java/com/redhat/darcy/webdriver/internal/ForwardingTargetedWebDriver.java
@@ -71,7 +71,7 @@ public class ForwardingTargetedWebDriver implements TargetedWebDriver, FindsByCl
         try {
             driver().getTitle();
             return true;
-        } catch (NotFoundException | SessionNotFoundException e) {
+        } catch (NotFoundException e) {
             return false;
         }
     }


### PR DESCRIPTION
This allows us to use FF47.  

The `SessionNotFoundException` I removed was changed to extend `NoSuchSessionException` and was deprecated. It's replacement `NoSuchSessionException` is a subclass of `NotFoundException`.