### PR TITLE
Use selenium 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ maven
 <dependency>
     <groupId>com.redhat.darcy</groupId>
     <artifactId>darcy-webdriver</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <version.synq>0.1.2-SNAPSHOT</version.synq>
         <version.darcy-web>0.3.0-SNAPSHOT</version.darcy-web>
-        <version.selenium>2.53.1</version.selenium>
+        <version.selenium>3.4.0</version.selenium>
         <version.operadriver>1.5</version.operadriver>
         <version.guice>4.0-beta5</version.guice>
         <version.guiceberry>3.3.1</version.guiceberry>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.redhat.darcy</groupId>
     <artifactId>darcy-webdriver</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/redhat/darcy/webdriver/WebDriverBrowser.java
+++ b/src/main/java/com/redhat/darcy/webdriver/WebDriverBrowser.java
@@ -44,9 +44,9 @@ import com.redhat.synq.Event;
 
 import org.hamcrest.Matcher;
 import org.openqa.selenium.NoSuchFrameException;
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.OutputType;
-import org.openqa.selenium.remote.SessionNotFoundException;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -365,7 +365,7 @@ public class WebDriverBrowser implements Browser, Frame, WebDriverWebContext, Wr
     private void attempt(Runnable action) {
         try {
             action.run();
-        } catch (NoSuchFrameException | NoSuchWindowException | SessionNotFoundException e) {
+        } catch (NoSuchFrameException | NoSuchWindowException | NoSuchSessionException e) {
             throw new FindableNotPresentException(this, e);
         }
     }
@@ -377,7 +377,7 @@ public class WebDriverBrowser implements Browser, Frame, WebDriverWebContext, Wr
     private <T> T attemptAndGet(Supplier<T> action) {
         try {
             return action.get();
-        } catch (NoSuchFrameException | NoSuchWindowException | SessionNotFoundException e) {
+        } catch (NoSuchFrameException | NoSuchWindowException | NoSuchSessionException e) {
             throw new FindableNotPresentException(this, e);
         }
     }

--- a/src/test/java/com/redhat/darcy/webdriver/FirefoxBrowserFactoryTest.java
+++ b/src/test/java/com/redhat/darcy/webdriver/FirefoxBrowserFactoryTest.java
@@ -21,6 +21,7 @@ package com.redhat.darcy.webdriver;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 import com.redhat.darcy.webdriver.internal.CachingTargetLocator;
@@ -37,6 +38,7 @@ public class FirefoxBrowserFactoryTest {
     @Before
     public void checkForDriver() {
         assumeTrue(System.getProperty("java.class.path").contains("firefox-driver"));
+        assumeNotNull(System.getProperty("webdriver.gecko.driver"));
     }
 
     @After


### PR DESCRIPTION
#72 

FYI, it looks a number of the BrowserDriver constructors have been deprecated in selenium 3.  Probably should also deprecate those in the darcy browser factories, but let me know what you think.